### PR TITLE
Option to ignore requests that match a regex

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,11 +16,13 @@ If you want this functionality in a Rails 2.x application, please refer to {this
 
 === Rails
 
-Just add the gem to your gemfile and run bundle 
+Just add the gem to your gemfile and run bundle
 
       gem 'route_downcaser'
 
-Then restart your Rails server. No configuration is needed. The gem simply hooks itself into the Rack middleware call stack.
+Then use the middleware where appripriate (probably config/application.rb)
+
+      config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware"
 
 If you have a controller named app/controllers/foo_controller.rb and the action index, you can now call it with:
 
@@ -55,6 +57,15 @@ will respond to all these requests:
       http://localhost:4567/foo
       http://localhost:4567/Foo
       http://localhost:4567/FOO
+
+== Configuration
+
+If you would like RouteDowncaser to ignore certain urls entirely, you can provide the :ignore option.
+
+Example:
+
+      # Ignore Devise password reset urls
+      config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware", ignore: /password_resets/
 
 == Background information
 

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -1,15 +1,37 @@
 module RouteDowncaser
   class DowncaseRouteMiddleware
-    def initialize(app)
+    def initialize(app, options = {})
       @app = app
+      @options = options
     end
 
     def call(env)
+      downcase_for_rails23(env)
+      downcase_for_rails3(env)
+
+      @app.call(env)
+    end
+
+    private
+
+    def ignore?(path)
+      if path && @options[:ignore]
+        path.match @options[:ignore]
+      end
+    end
+
+    def downcase_for_rails23(env)
+      return if ignore? env['REQUEST_URI']
+
       if env['REQUEST_URI']
         uri_items = env['REQUEST_URI'].split('?')
         uri_items[0].downcase!
         env['REQUEST_URI'] = uri_items.join('?')
       end
+    end
+
+    def downcase_for_rails3(env)
+      return if ignore? env['PATH_INFO']
 
       if env['PATH_INFO'] =~ /assets\//i
         pieces = env['PATH_INFO'].split('/')
@@ -17,8 +39,8 @@ module RouteDowncaser
       elsif env['PATH_INFO']
         env['PATH_INFO'] = env['PATH_INFO'].downcase
       end
-
-      @app.call(env)
     end
+
+
   end
 end

--- a/lib/route_downcaser/railtie.rb
+++ b/lib/route_downcaser/railtie.rb
@@ -1,8 +1,8 @@
 module RouteDowncaser
   class Railtie < Rails::Railtie
-    initializer "add_downcase_route_middleware" do |app|
-      app.config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware"
-    end
+    # initializer "add_downcase_route_middleware" do |app|
+    #   app.config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware"
+    # end
   end
 end
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -6,7 +6,7 @@ require "active_resource/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 
-# Auto-require default libraries and those for the current Rails environment. 
+# Auto-require default libraries and those for the current Rails environment.
 Bundler.require :default, Rails.env
 
 require "route_downcaser"
@@ -60,6 +60,8 @@ module Dummy
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware"
   end
 end
 

--- a/test/route_downcaser_test.rb
+++ b/test/route_downcaser_test.rb
@@ -40,4 +40,24 @@ class RouteDowncaserTest < ActiveSupport::TestCase
 
     assert_equal("assets/images/SpaceCat.jpeg", app.env['PATH_INFO'])
   end
+
+  test "urls can be left alone by configuration" do
+    app = MockApp.new
+    env = { 'PATH_INFO' => "password_resets/aBcDeF/edit" }
+
+    ignore = /^password_resets/
+    RouteDowncaser::DowncaseRouteMiddleware.new(app, :ignore => ignore).call(env)
+
+    assert_equal("password_resets/aBcDeF/edit", app.env['PATH_INFO'])
+  end
+
+  test "path is still downcased if ignore does not match" do
+    app = MockApp.new
+    env = { 'PATH_INFO' => "HELLO/WORLD" }
+
+    ignore = /^password_resets/
+    RouteDowncaser::DowncaseRouteMiddleware.new(app, :ignore => ignore).call(env)
+
+    assert_equal("hello/world", app.env['PATH_INFO'])
+  end
 end


### PR DESCRIPTION
RouteDowncaser smartly does not alter query params. However, sometimes there are case-sensitive params in the url proper. In my case, I am using [Devise](https://github.com/plataformatec/devise), and the password reset token is provided as the path part `:id` which is case-sensitive.

This patch fixes the issue by providing an `:ignore` option. To use this option, you must add `DowncaseRouteMiddleware` to the middleware stack yourself.

**Example:**

```ruby
# Ignore Devise password reset urls
config.middleware.use "RouteDowncaser::DowncaseRouteMiddleware", ignore: /password_resets/
```

My original goal was to alter the railtie to load the middleware only if it was not already loaded. However, I could not get this to work. I can go into detail on why I couldn't get this to work if you like, but it's fairly involved so I'm not gonna go into it here yet.

The simplest alternative is to simply not add the middleware to the stack by default. This is what I've done here because that works for me, but it would be a breaking change (maybe that's ok, as the gem is pre 1.0).

Another possibility would be to allow the middleware to be in the stack twice, but use an env var (like `env['route_downcaser.downcased'] = true` to guard multiple runs. However, this seems a little messy to me.

Anyway, here's a pull request in case you like the feature. I'm happy to discuss how to handle the initialization issue, but if you simply don't like this feature then I'll just continue using my branch.

Thanks,

-Amiel


