### PR TITLE
Adds config option for `exclude_patterns` and fixes issue with redirecting assets/ paths.

### DIFF
--- a/lib/route_downcaser.rb
+++ b/lib/route_downcaser.rb
@@ -6,4 +6,5 @@ module RouteDowncaser
   extend Configuration
 
   define_setting :redirect, false
+  define_setting :exclude_patterns, [/assets\//i]
 end

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -8,7 +8,7 @@ module RouteDowncaser
       @env = env
 
       if env['REQUEST_URI']
-        if RouteDowncaser.redirect == true
+        if RouteDowncaser.redirect == true && !exclude_patterns_match?(env['REQUEST_URI'])
           if path != path.downcase
             return [301, {'Location' => downcased_uri, 'Content-Type' => 'text/html'}, []]
           end
@@ -17,7 +17,7 @@ module RouteDowncaser
         end
       end
 
-      if env['PATH_INFO'] =~ /assets\//i
+      if exclude_patterns_match?(env['PATH_INFO'])
         pieces = env['PATH_INFO'].split('/')
         env['PATH_INFO'] = pieces.slice(0..-2).join('/').downcase + '/' + pieces.last
       elsif env['PATH_INFO']
@@ -47,6 +47,10 @@ module RouteDowncaser
       else
         path.downcase!
       end
+    end
+
+    def exclude_patterns_match?(uri)
+      uri.match(Regexp.union(RouteDowncaser.exclude_patterns)) if uri
     end
   end
 end


### PR DESCRIPTION
I noticed that with the `redirect` setting true, it was also redirecting requests to fetch assets.

This adds a configuration option to allow setting your own exclude patterns (in my case I also wanted `fonts/` excluded) and fixes the issue.