### PR TITLE
Revert "Update README.rdoc"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,9 +66,9 @@ Configuration options can be set using an initializer in your application like s
         config.redirect = true
 
         config.exclude_patterns = [
-          /\/assets\//i,
-          /\/fonts\//i,
-          /\/some\/important\/path/i
+          /assets\//i,
+          /fonts\//i,
+          /some\/important\/path/i
         ]
       end
 


### PR DESCRIPTION
Reverts carstengehling/route_downcaser#12  

I made a mistake with my commit. Locally I have to do:  

/\assets/ not /\/assets/ like was in the PR.  

However since the default exclude is set up as /assets/ (which does not work for me) and the readme was set up that way, I wonder if it is just something with my setup that requires the /\pathname/ or if it is indeed that way for everyone?