### PR TITLE
Refactor call method, to only return @app.call instead of return

### DIFF
--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -9,35 +9,35 @@ module RouteDowncaser
       new_env = env.clone
 
       # Don't touch anything, if uri/path is part of exclude_patterns
-      if exclude_patterns_match?(new_env['REQUEST_URI']) or exclude_patterns_match?(new_env['PATH_INFO'])
-        @app.call(new_env)
-        return
-      end
-
-      # Downcase request_uri and/or path_info if applicable
-      if new_env['REQUEST_URI'].present?
-        new_env['REQUEST_URI'] = downcased_uri(new_env['REQUEST_URI'])
-      end
-
-      if new_env['PATH_INFO'].present?
-        new_env['PATH_INFO'] = downcased_uri(new_env['PATH_INFO'])
-      end
-
-      # If redirect configured, then return redirect request,
-      # if either request_uri or path_info has changed
-      if RouteDowncaser.redirect
-        if new_env["REQUEST_URI"].present? and new_env["REQUEST_URI"] != env["REQUEST_URI"]
-          return redirect_header(new_env["REQUEST_URI"])
+      # binding.pry
+      unless exclude_patterns_match?(new_env['REQUEST_URI']) or exclude_patterns_match?(new_env['PATH_INFO'])
+        # Downcase request_uri and/or path_info if applicable
+        if new_env['REQUEST_URI'].present?
+          new_env['REQUEST_URI'] = downcased_uri(new_env['REQUEST_URI'])
         end
 
-        if new_env["PATH_INFO"].present? and new_env["PATH_INFO"] != env["PATH_INFO"]
-          return redirect_header(new_env["PATH_INFO"])
+        if new_env['PATH_INFO'].present?
+          new_env['PATH_INFO'] = downcased_uri(new_env['PATH_INFO'])
         end
+
+        # If redirect configured, then return redirect request,
+        # if either request_uri or path_info has changed
+        if RouteDowncaser.redirect
+          if new_env["REQUEST_URI"].present? and new_env["REQUEST_URI"] != env["REQUEST_URI"]
+            return redirect_header(new_env["REQUEST_URI"])
+          end
+
+          if new_env["PATH_INFO"].present? and new_env["PATH_INFO"] != env["PATH_INFO"]
+            return redirect_header(new_env["PATH_INFO"])
+          end
+        end
+
       end
 
       # Default just move to next chain in Rack callstack
       # calling with downcased uri if needed
       @app.call(new_env)
+
     end
 
     private

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -9,8 +9,8 @@ module RouteDowncaser
       new_env = env.clone
 
       # Don't touch anything, if uri/path is part of exclude_patterns
-      # binding.pry
-      unless exclude_patterns_match?(new_env['REQUEST_URI']) or exclude_patterns_match?(new_env['PATH_INFO'])
+
+      if (!exclude_patterns_match?(new_env['REQUEST_URI']) || !exclude_patterns_match?(new_env['PATH_INFO'])) && new_env['REQUEST_METHOD'] == "GET"
         # Downcase request_uri and/or path_info if applicable
         if new_env['REQUEST_URI'].present?
           new_env['REQUEST_URI'] = downcased_uri(new_env['REQUEST_URI'])


### PR DESCRIPTION
I'm using Rails  4.0.12 and the assets were behaving weird. I'm using this exclude_pattern `config.exclude_patterns = [ /\/assets\/.*/, /\/uploads\/.*/, /\/fonts\/.*/ ]` and the logic here https://github.com/carstengehling/route_downcaser/blob/master/lib/route_downcaser/downcase_route_middleware.rb#L12 was working correctly, but for some reason my app wasn't able to to find the `.css.scss` or `.js` and non of the images as well. so I started looking at the code and just remove the 'return' https://github.com/carstengehling/route_downcaser/blob/master/lib/route_downcaser/downcase_route_middleware.rb#L14  and it worked.  I refactored the code but in essence it's just that. 

I'm not sure why the return was causing me problems, and I wish to have more info.