### PR TITLE
Namespace Configuration module

### DIFF
--- a/lib/route_downcaser.rb
+++ b/lib/route_downcaser.rb
@@ -1,9 +1,9 @@
 require 'route_downcaser/downcase_route_middleware'
 require 'route_downcaser/railtie' if defined? Rails
-require 'configuration'
+require 'route_downcaser/configuration'
 
 module RouteDowncaser
-  extend Configuration
+  extend RouteDowncaser::Configuration
 
   define_setting :redirect, false
   define_setting :exclude_patterns, [/assets\//i]

--- a/lib/route_downcaser/configuration.rb
+++ b/lib/route_downcaser/configuration.rb
@@ -1,4 +1,4 @@
-module Configuration
+module RouteDowncaser::Configuration
 
   def configuration
     yield self


### PR DESCRIPTION
The Configuration module name was without namespace and prone to clashing with Configuration modules or classes on projects. We experienced such clashes and have fixed it by adding a namespace to the Configuration module in route_downcaser. This pull request adds that namespace.